### PR TITLE
Add ServiceLoader entry for the bolt driver

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,9 +32,6 @@ This project is composed by the following modules:
 === Minimum viable snippet ===
 
 ---------------------------------------------
-// Make sure Neo4j Driver is registered
-Class.forName("it.larusba.neo4j.jdbc.Driver");
-
 // Connect
 Connection con = DriverManager.getConnection("jdbc:bolt://localhost");
 

--- a/neo4j-jdbc-bolt/src/main/resources/META-INF/services/java.sql.Driver
+++ b/neo4j-jdbc-bolt/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,2 @@
+it.larusba.neo4j.jdbc.bolt.BoltDriver
+

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltAuthenticationIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltAuthenticationIT.java
@@ -20,7 +20,6 @@
 package it.larusba.neo4j.jdbc.bolt;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.driver.v1.exceptions.ClientException;
@@ -39,10 +38,6 @@ public class BoltAuthenticationIT {
 	@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule(true);  // here we're firing up neo4j with bolt enabled
 
 	private String NEO4J_JDBC_BOLT_URL;
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	@Before public void setup() {
 		NEO4J_JDBC_BOLT_URL = "jdbc:" + neo4j.getBoltUrl();

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltConnectionIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltConnectionIT.java
@@ -21,7 +21,6 @@ package it.larusba.neo4j.jdbc.bolt;
 
 import it.larusba.neo4j.jdbc.bolt.data.StatementData;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.driver.v1.Session;
@@ -41,10 +40,6 @@ public class BoltConnectionIT {
 	@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule();  // here we're firing up neo4j with bolt enabled
 
 	private String NEO4J_JDBC_BOLT_URL;
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	@Before public void setup() {
 		NEO4J_JDBC_BOLT_URL = "jdbc:" + neo4j.getBoltUrl();

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltDatabaseMetaDataIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltDatabaseMetaDataIT.java
@@ -21,7 +21,6 @@
  */
 package it.larusba.neo4j.jdbc.bolt;
 
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -42,10 +41,6 @@ import static org.junit.Assert.assertNotNull;
 public class BoltDatabaseMetaDataIT {
 
 	@Rule public Neo4jBoltRule neo4j = new Neo4jBoltRule();
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException, SQLException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	@Test public void getDatabaseVersionShouldBeOK() throws SQLException, NoSuchFieldException, IllegalAccessException {
 		Connection connection = DriverManager.getConnection("jdbc:" + neo4j.getBoltUrl());

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltPreparedStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltPreparedStatementIT.java
@@ -20,7 +20,6 @@
 package it.larusba.neo4j.jdbc.bolt;
 
 import it.larusba.neo4j.jdbc.bolt.data.StatementData;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
@@ -38,10 +37,6 @@ import static org.junit.Assert.*;
 public class BoltPreparedStatementIT {
 
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException, SQLException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	/*------------------------------*/
 	/*          executeQuery        */

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltResultSetMetaDataIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltResultSetMetaDataIT.java
@@ -24,7 +24,6 @@ import org.junit.*;
 
 import java.sql.*;
 import java.util.Map;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -37,10 +36,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class BoltResultSetMetaDataIT {
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException, SQLException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	@Before public void setUp() {
 		neo4j.getGraphDatabase().execute(StatementData.STATEMENT_CREATE_TWO_PROPERTIES);

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltStatementIT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/BoltStatementIT.java
@@ -20,7 +20,6 @@
 package it.larusba.neo4j.jdbc.bolt;
 
 import it.larusba.neo4j.jdbc.bolt.data.StatementData;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
@@ -36,10 +35,6 @@ import static org.junit.Assert.*;
 public class BoltStatementIT {
 
 	@ClassRule public static Neo4jBoltRule neo4j = new Neo4jBoltRule();
-
-	@BeforeClass public static void initialize() throws ClassNotFoundException, SQLException {
-		Class.forName("it.larusba.neo4j.jdbc.bolt.BoltDriver");
-	}
 
 	/*------------------------------*/
 	/*          executeQuery        */

--- a/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/SamplePT.java
+++ b/neo4j-jdbc-bolt/src/test/java/it/larusba/neo4j/jdbc/bolt/SamplePT.java
@@ -43,7 +43,6 @@ public class SamplePT {
 
 	@Test public void launchBenchmark() throws Exception {
 
-		Class.forName("BoltDriver");
 		Connection conn = DriverManager.getConnection("jdbc:bolt://localhost:7687");
 		Statement stmt = conn.createStatement();
 		ResultSet rs = stmt.executeQuery("MATCH (n) RETURN n");
@@ -83,10 +82,6 @@ public class SamplePT {
 	}
 
 	@State(Scope.Thread) public static class Data {
-		@Setup public static void initialize() throws ClassNotFoundException, SQLException, IOException {
-			Class.forName("BoltDriver");
-		}
-
 		public String query = "MATCH (n) RETURN n";
 	}
 


### PR DESCRIPTION
Since JDBC4 the java ServiceLoader API is supported to
load JDBC drivers from the classpath. Therefore it
isn't any longer necessary to call `Class.forName(..)`
in your application.