### PR TITLE
Use UTF-8 as fixed encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
     </dependencies>
 
     <properties>
+        <encoding>UTF-8</encoding>
         <powermock.version>1.6.2</powermock.version>
         <junit.version>4.12</junit.version>
     </properties>


### PR DESCRIPTION
Relying on the default platform enconding may result
into problems. Therefore the encoding should be set
to a fixed value. Today UTF-8 is supported on every
operating system and therefore a good choice.