### PR TITLE
fix transaction isolation level check bug

### DIFF
--- a/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
+++ b/neo4j-jdbc/src/main/java/org/neo4j/jdbc/impl/Neo4jConnectionImpl.java
@@ -229,7 +229,7 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 	 */
 	protected void checkTransactionIsolation(int level) throws SQLException {
 		// @formatter:off
-		int[] invalid = {
+		Integer[] invalid = {
 			TRANSACTION_NONE,
 			TRANSACTION_READ_COMMITTED,
 			TRANSACTION_READ_UNCOMMITTED,
@@ -238,7 +238,7 @@ public abstract class Neo4jConnectionImpl implements Neo4jConnection {
 		};
 
 		if(!Arrays.asList(invalid).contains(level)){
-			throw new SQLException();
+			new SQLException("Unsupported isolation level");
 		}
 		// @formatter:on
 	}


### PR DESCRIPTION
protected void checkTransactionIsolation(int level) throws SQLException {
		// @formatter:off
               // here array should use Integer instead of int
		Integer[] invalid = {
			TRANSACTION_NONE,
			TRANSACTION_READ_COMMITTED,
			TRANSACTION_READ_UNCOMMITTED,
			TRANSACTION_REPEATABLE_READ,
			TRANSACTION_SERIALIZABLE
		};
               // I add a friendly exception tip
		if(!Arrays.asList(invalid).contains(level)){
			new SQLException("Unsupported isolation level");
		}
		// @formatter:on
	}